### PR TITLE
fix: Scroll adds white strip at bottom on safari

### DIFF
--- a/packages/react-pdf/package.json
+++ b/packages/react-pdf/package.json
@@ -75,6 +75,7 @@
     "make-event-props": "^1.6.0",
     "merge-refs": "^1.2.1",
     "prop-types": "^15.6.2",
+    "seamless-scroll-polyfill": "^2.3.4",
     "tiny-invariant": "^1.0.0",
     "warning": "^4.0.0"
   },

--- a/packages/react-pdf/src/Document.tsx
+++ b/packages/react-pdf/src/Document.tsx
@@ -70,6 +70,7 @@ import type {
 import Page, { type PageProps } from './Page.js';
 import { PDFFindController } from './shared/pdf_find_controller.js';
 import { DownloadManager } from './shared/download_manager.js';
+import { scrollIntoView } from 'seamless-scroll-polyfill';
 
 const { PDFDataRangeTransport } = pdfjs;
 
@@ -289,7 +290,11 @@ class Viewer {
 
     if (page) {
       // Scroll to the page automatically
-      page.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+      scrollIntoView(page, {
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'nearest',
+      });
       this.currentPageNumber = pageNumber;
       return;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1879,7 +1879,7 @@ eslint-module-utils@^2.7.4, eslint-module-utils@^2.8.0:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@^2.25.0, "eslint-plugin-import@npm:eslint-plugin-i@^2.28.0":
+eslint-plugin-import@^2.25.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-i/-/eslint-plugin-i-2.29.1.tgz#97e4a055b6b2040cec0842700dd1d2066773b5a4"
   integrity sha512-ORizX37MelIWLbMyqI7hi8VJMf7A0CskMmYkB+lkCX3aF4pkGV7kwx5bSEb4qx7Yce2rAf9s34HqDRPjGRZPNQ==
@@ -3860,6 +3860,11 @@ scheduler@^0.23.2:
   integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
   dependencies:
     loose-envify "^1.1.0"
+
+seamless-scroll-polyfill@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/seamless-scroll-polyfill/-/seamless-scroll-polyfill-2.3.4.tgz#d2fd1833993a2ad41a3ac319c65dc839bf0746d5"
+  integrity sha512-Biobd4LDoeFODX1bfiru84GveSajzFELFB3ejMZsRR2TpD73W46uEZYAEqSx5RtKpN2umhGWaoSRivs0ZcHp9g==
 
 semver@^6.0.0, semver@^6.3.1:
   version "6.3.1"


### PR DESCRIPTION
<!-- See https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ for more info -->
<!-- Remove any sections that are not needed before submitting the PR -->


## What does this change do?
- On clicking the bookmark, scrollIntoView adds a white strip at the bottom on Safari. To fix the issue, I added the [seamless-scroll-polyfill](https://www.npmjs.com/package/seamless-scroll-polyfill#import-via-script) package.


